### PR TITLE
Add test helper tool

### DIFF
--- a/lib/build/build-helpers.js
+++ b/lib/build/build-helpers.js
@@ -70,15 +70,6 @@
           description: 'Start the express app of the service.'
         });
 
-        tasks.push({
-          name: 'test',
-          run: function () {
-            // TODO: run mocha / coveralls etc.
-            return false;
-          },
-          description: 'Runs all tests of the service.'
-        });
-
         // add tasks declared by features to build
         var features = plugins.loadFeatures(configuration);
         _.each(features, function(featureDescription) {
@@ -88,7 +79,7 @@
               name: task.name,
               description: task.description,
               run: function () {
-                return task.run(featureDescription.featureDef.config, configuration);
+                return task.run(featureDescription.featureDef.config, configuration, servicePath);
               }
             });
           });

--- a/lib/testing/TestHelper.js
+++ b/lib/testing/TestHelper.js
@@ -1,0 +1,44 @@
+'use strict';
+
+var main = require('../app/express/main')
+  , request = require('../http/request')
+  , path = require('path')
+  , _ = require('lodash');
+
+function TestHelper(config) {
+  this.serverUrl = getAppAddress(config);
+  this.request = request(this.serverUrl);
+  this.app = main.createApp(config);
+
+  var self = this;
+  before(function () {
+    return main.startApp(self.app);
+  });
+
+  after(function () {
+    self.app.server.close();
+  });
+}
+
+TestHelper.instances = {};
+
+TestHelper.getHelper = function (config) {
+  // Check if helper is already instantiated for this service (identified by address)
+  var serviceIdentifier = getAppAddress(config);
+  var instance = TestHelper.instances[serviceIdentifier];
+  if (!instance) {
+    instance = new TestHelper(config);
+    TestHelper.instances[serviceIdentifier] = instance;
+  }
+
+  return instance;
+}
+
+/**
+ * @private
+ */
+function getAppAddress(config) {
+  return config.protocol + '://localhost:' + config.port;
+}
+
+module.exports = TestHelper;

--- a/lib/utils/TestHelper.js
+++ b/lib/utils/TestHelper.js
@@ -5,6 +5,18 @@ var main = require('../app/express/main')
   , path = require('path')
   , _ = require('lodash');
 
+/**
+ * `TestHelper` provides methods for writing tests.
+ *
+ * Use `TestHelper.getHelper` utility method to return shared TestHelper
+ * instance for test run.
+ *
+ * Instantiating TestHelper creates bindings to mocha's lifecycle methods for starting
+ * and stopping the application instance.
+ *
+ * @param {object} config
+ *    The configuration object of the service we are testing.
+ */
 function TestHelper(config) {
   this.serverUrl = getAppAddress(config);
   this.request = request(this.serverUrl);

--- a/lib/utils/run-command-in-promise.js
+++ b/lib/utils/run-command-in-promise.js
@@ -1,0 +1,30 @@
+var spawn = require('child_process').spawn;
+var Promise = require('bluebird');
+var _ = require('lodash');
+
+// Run the command in a bourne-compatible shell to get shebang lines interpreted correctly
+// Note: child_process.exec almost does what we want, but would use sucky cmd.exe in windows
+var SHELL = 'sh';
+
+function runCommandInPromise(command, parameters, spawnOptions, options) {
+  if (options && !options.silent) {
+    console.log("Running:", command, JSON.stringify(parameters), JSON.stringify(spawnOptions));
+  }
+  return new Promise(function (resolve, reject) {
+    var child = spawn(SHELL, ['-c', command + ' ' + parameters.join(' ')], spawnOptions);
+    child.on('close', function (code) {
+      if (code === 0) {
+        resolve(child);
+      } else {
+        reject(new Error('process exited with failure status ' + code));
+      }
+    });
+    child.on('error', function (err) {
+      reject(err);
+      child.removeAllListeners();
+      child.on('error', _.noop); // avoid crashes from further uncaught errors
+    });
+  });
+}
+
+module.exports = runCommandInPromise;

--- a/tests/build/build-helpers.spec.js
+++ b/tests/build/build-helpers.spec.js
@@ -26,9 +26,8 @@ describe('build-helpers.js', function () {
     });
 
     it('should have core tasks registered', function () {
-      expect(services[0].tasks).to.have.length(2);
+      expect(services[0].tasks).to.have.length(1);
       expect(_.find(services[0].tasks, { name: 'serve' })).to.be.truthy;
-      expect(_.find(services[0].tasks, { name: 'test' })).to.be.truthy;
     });
 
     it('should have configuration', function () {
@@ -81,17 +80,17 @@ describe('build-helpers.js', function () {
   it('should register tasks of the features', function () {
     var services = buildHelpers.scanServices(path.join(__dirname, 'test-service-path'), 'feature-with-tasks');
     expect(services).to.have.length(1);
-    expect(services[0].tasks).to.have.length(3);
-    expect(services[0].tasks[2].name).to.equal('feature-task');
-    expect(services[0].tasks[2].description).to.equal('Does pretty much nothing');
-    expect(services[0].tasks[2].run().config.port).to.equal(9001);
-    expect(services[0].tasks[2].run().featureConfig.shouldPassFeatureConfigToo).to.equal(true);
+    expect(services[0].tasks).to.have.length(2);
+    expect(services[0].tasks[1].name).to.equal('feature-task');
+    expect(services[0].tasks[1].description).to.equal('Does pretty much nothing');
+    expect(services[0].tasks[1].run().config.port).to.equal(9001);
+    expect(services[0].tasks[1].run().featureConfig.shouldPassFeatureConfigToo).to.equal(true);
   });
 
   it('should run serve task', function () {
     var services = buildHelpers.scanServices(path.join(__dirname, 'test-service-path'), 'realdeal');
     expect(services).to.have.length(1);
-    expect(services[0].tasks).to.have.length(2);
+    expect(services[0].tasks).to.have.length(1);
     return services[0].tasks[0].run().then(function (app) {
       expect(app.config).to.be.ok;
       return new Promise(function (resolve) {
@@ -100,12 +99,4 @@ describe('build-helpers.js', function () {
     });
   });
 
-  it('should run test task', function () {
-    var services = buildHelpers.scanServices(path.join(__dirname, 'test-service-path'), 'realdeal');
-    expect(services).to.have.length(1);
-    expect(services[0].tasks).to.have.length(2);
-    return Promise.resolve(services[0].tasks[1].run()).then(function (result) {
-      expect(result).to.be.false;
-    });
-  });
 });


### PR DESCRIPTION
For setting up support for mocha tests.

Old 'test' task is implemented by projects since test commands are quite specific to project requirements.