### PR TITLE
Create http server before features are initialised

### DIFF
--- a/lib/app/express/main.js
+++ b/lib/app/express/main.js
@@ -23,11 +23,7 @@ function startServer(app) {
           resolve(app);
         }
       };
-      if (app.config.protocol === 'https') {
-        startHttpsServer(app, callback);
-      } else {
-        startHttpServer(app, callback);
-      }
+      startHttpServer(app, callback);
     } catch(err) {
       reject(err);
     }
@@ -40,9 +36,9 @@ function startServer(app) {
 /**
  * @private
  */
-function startHttpsServer(app, callback) {
+function createHttpsServer(app) {
   if (!app.config.ssl || !app.config.ssl.key || !app.config.ssl.cert) {
-    callback(new Error("Https requires ssl configuration with key and cert"));
+    throw new Error("Https requires ssl configuration with key and cert");
   }
   var sslOptions = {
     key: fs.readFileSync(app.config.ssl.key, 'utf8'),
@@ -50,15 +46,19 @@ function startHttpsServer(app, callback) {
     passphrase: app.config.ssl.passphrase
   };
   app.server = require('https').createServer(sslOptions, app);
-  app.server.on('error', callback);
-  app.server.listen(app.config.port, void 0, void 0, callback);
+}
+
+/**
+ * @private
+ */
+function createHttpServer(app) {
+  app.server = require('http').createServer(app);
 }
 
 /**
  * @private
  */
 function startHttpServer(app, callback) {
-  app.server = require('http').createServer(app);
   app.server.on('error', callback);
   app.server.listen(app.config.port, void 0, void 0, callback);
 }
@@ -154,6 +154,12 @@ module.exports = {
       req.app = app;
       next();
     });
+
+    if (app.config.protocol === 'https') {
+      createHttpsServer(app);
+    } else {
+      createHttpServer(app);
+    }
 
     log.trace("Initializing features");
     app = plugins.initFeatures(app);

--- a/tests/app/main.spec.js
+++ b/tests/app/main.spec.js
@@ -110,13 +110,10 @@ describe('main.js app create / start', function () {
   describe('startServer(app)', function () {
     it('should throw an error if config.protocol == https and no ssl config given', function () {
       okConfig.protocol = 'https';
-      var app = main.createApp(okConfig);
-      return new Promise(function (resolve, reject) {
-        // fail promise if start app is success and success if starting is fail
-        main.startApp(app).then(reject).catch(resolve);
-      }).then(function (err) {
-        expect(err.message).to.contain("Https requires ssl configuration with key and cert");
-      });
+      var fn = function () {
+        main.createApp(okConfig);
+      };
+      expect(fn).to.throw("Https requires ssl configuration with key and cert");
     });
 
     it('should be able to create https server with key, cert and passphrase', function () {
@@ -152,11 +149,10 @@ describe('main.js app create / start', function () {
         key: path.join(__dirname, 'data', 'server.key'),
         cert: path.join(__dirname, 'data', 'server.crt')
       };
-      var app = main.createApp(okConfig);
-      return new Promise(function (resolve, reject) {
-        // fail promise if start app is success and success if starting is fail
-        main.startApp(app).then(reject).catch(resolve);
-      });
+      var fn = function () {
+        main.createApp(okConfig);
+      };
+      expect(fn).to.throw;
     });
 
     it('should emit serverStart event after server is started', function () {
@@ -176,13 +172,10 @@ describe('main.js app create / start', function () {
     it('should return startup error also if not in testing profile (NOTE: shows an error during tests)', function () {
       delete okConfig['profile'];
       okConfig.protocol = 'https';
-      var app = main.createApp(okConfig);
-      return new Promise(function (resolve, reject) {
-        // fail promise if start app is success and success if starting is fail
-        main.startApp(app).then(reject).catch(resolve);
-      }).then(function (err) {
-        expect(err.message).to.contain("Https requires ssl configuration with key and cert");
-      });
+      var fn = function () {
+        main.createApp(okConfig);
+      };
+      expect(fn).to.throw("Https requires ssl configuration with key and cert");
     });
   });
 


### PR DESCRIPTION
For example socket.io requires a valid (but not listening) http server instance in feature constructor.